### PR TITLE
Add integration specs on web app

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: test
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ Personally I love the following:
       implement whatever you need. I don't really like that as moving from one library to another might become a pain as
       you need to glue them together.
 * [testcontainers](http://testcontainers.org/)
-    * Framework for running your dependencies. This framework is great it can ran almost anything without any complications.
-    * I worked with the creator [@rnorth](https://github.com/rnorth) while I was at skyscanner and it made our services very resilient and reliable.
+    * Framework for running your dependencies. This framework is great it can ran almost anything without any
+      complications.
+    * I worked with the creator [@rnorth](https://github.com/rnorth) while I was at skyscanner and it made our services
+      very resilient and reliable.
 
 ## Goals
 

--- a/cmd/web/di.go
+++ b/cmd/web/di.go
@@ -17,7 +17,6 @@ var WebModule = fx.Module("web",
 	fx.Invoke(invokeRoutes, invokeHttpServer),
 )
 
-// provideRouter HTTP Stuff
 func provideRouter(logger *zap.Logger) *gin.Engine {
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()

--- a/cmd/web/di.go
+++ b/cmd/web/di.go
@@ -25,17 +25,12 @@ func provideRouter(logger *zap.Logger) *gin.Engine {
 	return r
 }
 
-func provideWebHandler(logger *zap.Logger, router *gin.Engine, db *gorm.DB) *WebHandler {
+func provideWebHandler(logger *zap.Logger, router *gin.Engine, db *gorm.DB) IRoutes {
 	return &WebHandler{
 		Logger: logger,
 		R:      router,
 		db:     db,
 	}
-}
-
-func invokeRoutes(r *gin.Engine, h *WebHandler) {
-	r.GET("/", h.Hello)
-	r.GET("/ping", h.Ping)
 }
 
 func invokeHttpServer(lc fx.Lifecycle, ginEngine *gin.Engine, logger *zap.Logger) {

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -5,9 +5,10 @@ import (
 	"goprod/internal/di"
 )
 
+func opts() fx.Option {
+	return fx.Options(di.ApplicationModule, WebModule)
+}
+
 func main() {
-	fx.New(
-		di.ApplicationModule, WebModule,
-		fx.WithLogger(di.FxEvent),
-	).Run()
+	fx.New(opts(), fx.WithLogger(di.FxEvent)).Run()
 }

--- a/cmd/web/main_test.go
+++ b/cmd/web/main_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"go.uber.org/fx"
+	"testing"
+)
+
+func TestWebApp(t *testing.T) {
+	t.Parallel()
+
+	t.Run("TestDependenciesAreSatisfied", func(t *testing.T) {
+		t.Parallel()
+
+		if err := fx.ValidateApp(opts()); err != nil {
+			t.Error(err)
+		}
+	})
+}

--- a/cmd/web/routes.go
+++ b/cmd/web/routes.go
@@ -8,10 +8,20 @@ import (
 	"net/http"
 )
 
+type IRoutes interface {
+	Hello(c *gin.Context)
+	Ping(c *gin.Context)
+}
+
 type WebHandler struct {
 	Logger *zap.Logger
 	R      *gin.Engine
 	db     *gorm.DB
+}
+
+func invokeRoutes(r *gin.Engine, h IRoutes) {
+	r.GET("/", h.Hello)
+	r.GET("/ping", h.Ping)
 }
 
 func (h *WebHandler) Hello(c *gin.Context) {

--- a/cmd/web/routes_test.go
+++ b/cmd/web/routes_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx/fxtest"
+	"goprod/internal/models"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+type Message struct {
+	Message string `json:"message"`
+}
+
+func TestRoutes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Hello", func(t *testing.T) {
+		t.Parallel()
+		app := fxtest.New(t, opts())
+		// Starts the app right away, and defers a stop when the test ends.
+		defer app.RequireStart().RequireStop()
+
+		resp, err := http.Get("http://localhost:8080/")
+		if err != nil {
+			panic(err.Error())
+		}
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			panic(err.Error())
+		}
+
+		var message = Message{}
+		err = json.Unmarshal(body, &message)
+		if err != nil {
+			panic(err.Error())
+		}
+
+		assert.Equal(t, "hello", message.Message)
+	})
+
+	t.Run("Ping", func(t *testing.T) {
+		t.Parallel()
+
+		app := fxtest.New(t, opts())
+		// Starts the app right away, and defers a stop when the test ends.
+		defer app.RequireStart().RequireStop()
+
+		resp, err := http.Get("http://localhost:8080/ping")
+		if err != nil {
+			panic(err.Error())
+		}
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			panic(err.Error())
+		}
+
+		var product = models.Product{}
+		err = json.Unmarshal(body, &product)
+		if err != nil {
+			panic(err.Error())
+		}
+
+		assert.Equal(t, "D42", product.Code)
+		assert.Equal(t, uint(100), product.Price)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/gin-contrib/zap v0.0.2
 	github.com/gin-gonic/gin v1.8.1
+	github.com/stretchr/testify v1.7.1
 	go.uber.org/fx v1.18.1
 	go.uber.org/zap v1.22.0
 	gorm.io/driver/sqlite v1.3.6
@@ -13,6 +14,7 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
@@ -27,6 +29,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/ugorji/go/codec v1.2.7 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/dig v1.15.0 // indirect
@@ -37,4 +40,5 @@ require (
 	golang.org/x/text v0.3.6 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,7 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/driver/sqlite v1.3.6 h1:Fi8xNYCUplOqWiPa3/GuCeowRNBRGTf62DEmhMDHeQQ=
 gorm.io/driver/sqlite v1.3.6/go.mod h1:Sg1/pvnKtbQ7jLXxfZa+jSHvoX8hoZA8cn4xllOMTgE=
 gorm.io/gorm v1.23.1/go.mod h1:l2lP/RyAtc1ynaTjFksBde/O8v9oOGIApu2/xRitmZk=

--- a/internal/di/application_test.go
+++ b/internal/di/application_test.go
@@ -1,0 +1,18 @@
+package di
+
+import (
+	"go.uber.org/fx"
+	"testing"
+)
+
+func TestApp(t *testing.T) {
+	t.Parallel()
+
+	t.Run("TestDependenciesAreSatisfied", func(t *testing.T) {
+		t.Parallel()
+
+		if err := fx.ValidateApp(ApplicationModule); err != nil {
+			t.Error(err)
+		}
+	})
+}


### PR DESCRIPTION
You were thinking i was going to do all this without tests? You don't know me well. I love good tests of different kinds. Here for now i just want to know that the DI stuff plays well and that i can actually call the API as if i was a user.

For that I'm using something the fx framework provides, `fxtest`. This lets me check that the dependency tree complies and it's happy and also to spin up the application to do calls to it.

Knowing that I have some test coverage I refactored the http routing to use an interface instead of relying on a struct. This will allow me have better tests for this in the future.