### PR TITLE
Ensure we can ran e2e tests in parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,22 +32,8 @@ jobs:
       - name: test
         run: make test
 
-        # only report code coverage on linux
       - name: Upload coverage report
         uses: codecov/codecov-action@v3
         with:
           files: ./cover.out
           name: goprod
-
-      - name: Create test summary
-        uses: test-summary/action@v1
-        with:
-          paths: unit-tests.xml
-          output: test-results.html
-        if: always()
-      - name: Upload test summary
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-summary
-          path: test-results.html
-        if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,15 @@ jobs:
           files: ./cover.out
           name: goprod
 
-      - name: Test Summary
+      - name: Create test summary
         uses: test-summary/action@v1
         with:
-          paths: "unit-tests.xml"
+          paths: unit-tests.xml
+          output: test-results.html
+        if: always()
+      - name: Upload test summary
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-summary
+          path: test-results.html
         if: always()

--- a/config_test.yml
+++ b/config_test.yml
@@ -1,5 +1,5 @@
 web:
-  addr: ":8080"
+  addr: ":0"
 
 database:
   host: localhost

--- a/internal/di.go
+++ b/internal/di.go
@@ -29,14 +29,19 @@ func provideLogger() *zap.Logger {
 }
 
 type AppConfig struct {
-	Build    BuildConfig
-	DBConfig DBConfig `yaml:"db_config"`
+	Build     BuildConfig
+	WebConfig WebConfig `yaml:"web"`
+	DBConfig  DBConfig  `yaml:"database"`
 }
 
 type BuildConfig struct {
 	ConfigFile string
 	Sha        string
 	Date       string
+}
+
+type WebConfig struct {
+	Addr string `yaml:"addr"`
 }
 
 type DBConfig struct {

--- a/internal/test_utils.go
+++ b/internal/test_utils.go
@@ -21,7 +21,7 @@ var TestModule = fx.Module("test",
 			// Root folder of this project
 			Root := filepath.Join(filepath.Dir(b), "..")
 			return BuildConfig{
-				ConfigFile: fmt.Sprintf("%s/config.yml", Root),
+				ConfigFile: fmt.Sprintf("%s/config_test.yml", Root),
 				Sha:        "test",
 				Date:       time.UnixDate,
 			}

--- a/internal/test_utils.go
+++ b/internal/test_utils.go
@@ -2,19 +2,26 @@ package internal
 
 import (
 	"context"
+	"fmt"
 	"github.com/docker/go-connections/nat"
 	_ "github.com/lib/pq"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"go.uber.org/fx"
+	"path/filepath"
+	"runtime"
 	"time"
 )
 
 var TestModule = fx.Module("test",
 	fx.Provide(
 		func() BuildConfig {
+			_, b, _, _ := runtime.Caller(0)
+
+			// Root folder of this project
+			Root := filepath.Join(filepath.Dir(b), "..")
 			return BuildConfig{
-				ConfigFile: "config.yml",
+				ConfigFile: fmt.Sprintf("%s/config.yml", Root),
 				Sha:        "test",
 				Date:       time.UnixDate,
 			}

--- a/internal/web/routes_test.go
+++ b/internal/web/routes_test.go
@@ -24,18 +24,17 @@ func TestRoutes(t *testing.T) {
 	t.Run("Hello", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
-
-		pg, err := internal.TestWithPostgres(ctx)
+		data, err := internal.TestWithPostgres(ctx)
 		assert.NoError(t, err)
 		defer func(postgresC testcontainers.Container, ctx context.Context) {
-			err := pg.Container.Terminate(ctx)
+			err := data.Container.Terminate(ctx)
 			if err != nil {
 				t.Error(err)
 			}
-		}(pg.Container, ctx)
+		}(data.Container, ctx)
 
 		var port Port
-		app := fxtest.New(t, internal.TestModule, Module, fx.Populate(&port))
+		app := fxtest.New(t, internal.TestModule, Module, fx.Replace(data.Config), fx.Populate(&port))
 		defer app.RequireStart().RequireStop()
 
 		resp, err := http.Get(fmt.Sprintf("http://localhost:%s/", port))


### PR DESCRIPTION
Fixes: #11 

Stop using a default port and instead make go create a random one that is not used. This ensures that we can run all the specs in parallel.