### PR TITLE
Ensure logger includes build config like sha or build date.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ test:
 	go run gotest.tools/gotestsum \
 		--format short-verbose \
 		--packages="./..." \
-		--junitfile unit-tests.xml \
 		--rerun-fails=3 \
 		-- -coverprofile=cover.out
 

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -53,6 +53,7 @@ func main() {
 									ConfigFile: cCtx.String("config"),
 									Sha:        Version,
 									Date:       Date,
+									DevMode:    false,
 								}
 							},
 						),

--- a/internal/di.go
+++ b/internal/di.go
@@ -21,10 +21,12 @@ var Module = fx.Module("app",
 	fx.Invoke(invokeMigrate),
 )
 
-func provideLogger() *zap.Logger {
-	logger, _ := zap.NewProduction(
-		zap.AddCaller(),
-	)
+func provideLogger(bcfg BuildConfig) *zap.Logger {
+	cfg := zap.NewProductionConfig()
+	cfg.InitialFields = map[string]interface{}{"sha": bcfg.Sha, "build_date": bcfg.Date}
+	cfg.Development = bcfg.DevMode
+	logger, _ := cfg.Build(zap.AddCaller())
+
 	return logger
 }
 
@@ -38,6 +40,7 @@ type BuildConfig struct {
 	ConfigFile string
 	Sha        string
 	Date       string
+	DevMode    bool
 }
 
 type WebConfig struct {

--- a/internal/test_utils.go
+++ b/internal/test_utils.go
@@ -24,6 +24,7 @@ var TestModule = fx.Module("test",
 				ConfigFile: fmt.Sprintf("%s/config_test.yml", Root),
 				Sha:        "test",
 				Date:       time.UnixDate,
+				DevMode:    true,
 			}
 		},
 	),


### PR DESCRIPTION
Adding such fields make debugging an error easier.
Additionally I stop generating a junit output since it's not usable. We
stop the ci pipeline from using it in the previous PR #17